### PR TITLE
Check whether output generation rule is present to avoid exceptions

### DIFF
--- a/src/main/java/de/viadee/bpm/vPAV/Runner.java
+++ b/src/main/java/de/viadee/bpm/vPAV/Runner.java
@@ -346,7 +346,8 @@ public class Runner {
 		for (String file : allOutputFilesArray)
 			outputFiles.add(Paths.get(fileMapping.get(file), file));
 
-		if (rules.get("CreateOutputHTML").isActive()) {			
+		if (rules.containsKey(ConfigConstants.CREATE_OUTPUT_RULE) &&
+				rules.get(ConfigConstants.CREATE_OUTPUT_RULE).isActive()) {
 			for (String file : allOutputFilesArray)
 				copyFileToVPAVFolder(file);
 		}

--- a/src/main/java/de/viadee/bpm/vPAV/constants/ConfigConstants.java
+++ b/src/main/java/de/viadee/bpm/vPAV/constants/ConfigConstants.java
@@ -113,6 +113,8 @@ public final class ConfigConstants {
 
     public static final String CRITICALITY = "Criticality";
 
+    public static final String CREATE_OUTPUT_RULE = "CreateOutputHTML";
+
     private ConfigConstants() {
     }
 


### PR DESCRIPTION
I wanted to execute vPAV in an exisiting project and got an exception, because the new rule for generating output wasn't present. So I made this change, happy to hear feeback!